### PR TITLE
Line Splitting for EdgeList and Adjacency Input Format

### DIFF
--- a/src/main/java/edu/cmu/graphchi/preprocessing/FastSharder.java
+++ b/src/main/java/edu/cmu/graphchi/preprocessing/FastSharder.java
@@ -16,6 +16,7 @@ import java.io.*;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.zip.DeflaterOutputStream;
 
 /**
@@ -680,13 +681,14 @@ public class FastSharder <VertexValueType, EdgeValueType> {
 
 
         if (!format.equals(GraphInputFormat.MATRIXMARKET)) {
+        	Pattern pat = Pattern.compile("\\s+");
             while ((ln = ins.readLine()) != null) {
                 if (ln.length() > 2 && !ln.startsWith("#")) {
                     lineNum++;
                     if (lineNum % 2000000 == 0) logger.info("Reading line: " + lineNum);
 
                     // trim line and split along consecutive whitespaces
-                    String[] tok = ln.trim().split("\\s+");
+                    String[] tok = pat.split(ln.trim());
 
                     if (tok.length > 1) {
                         if (format == GraphInputFormat.EDGELIST) {


### PR DESCRIPTION
I tried to run GraphChi with the provided small netflix dataset ( http://graphlab.org/wp-content/uploads/2013/07/smallnetflix_mm.train_.gz ).
However, since there are two whitespaces between dst and value, the splitting did not work.
Therefore I changed the line splitter to be more generic by first trimming the line and then splitting along consecutive whitespaces such as spaces and tabs.
